### PR TITLE
refactor(now): use channels for data synchronization

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -52,7 +52,7 @@ in
     ];
 
     postInstall = ''
-      installShellCompletion --cmd am \
+      installShellCompletion --cmd ${pname} \
         --bash <("$out/bin/${pname}" completions bash) \
         --zsh <("$out/bin/${pname}" completions zsh) \
         --fish <("$out/bin/${pname}" completions fish)

--- a/src/cmd/now.rs
+++ b/src/cmd/now.rs
@@ -131,7 +131,6 @@ async fn update_display(data: &PlaybackState, options: &NowOptions) -> Result<()
     } else {
         let position = data
             .position
-            .clone()
             .ok_or_else(|| anyhow!("Could not obtain position from shared playback state"))?;
         let track = data
             .track
@@ -185,7 +184,7 @@ async fn receive_delta(
         }
 
         PlaybackStateDelta::Position(position) => {
-            data.position = position.clone();
+            data.position = *position;
         }
 
         PlaybackStateDelta::PositionTick => {
@@ -198,17 +197,14 @@ async fn receive_delta(
 
         PlaybackStateDelta::TrackIDRequestMoreInfo(id) => {
             if let Some(track) = &data.track {
-                tx_request_track
-                    .send(track.id != id.to_string())
-                    .await
-                    .unwrap();
+                tx_request_track.send(track.id != *id).await.unwrap();
             } else {
                 tx_request_track.send(true).await.unwrap();
             };
         }
 
         PlaybackStateDelta::Render => {
-            if let Err(err) = update_display(&data, &options).await {
+            if let Err(err) = update_display(data, options).await {
                 eprintln!("{}", err);
             };
         }

--- a/src/cmd/now.rs
+++ b/src/cmd/now.rs
@@ -30,6 +30,7 @@ enum PlaybackStateDelta {
     TrackIDRequestMoreInfo(String),
     Track(Option<Track>),
     Playlist(Option<Playlist>),
+    Render,
 }
 
 #[derive(Debug, Clone)]
@@ -105,6 +106,8 @@ async fn update_state(
             tx.send(PlaybackStateDelta::Playlist(None)).await?;
         };
     }
+
+    tx.send(PlaybackStateDelta::Render).await?;
 
     Ok(())
 }
@@ -266,11 +269,13 @@ pub async fn now(options: NowOptions) -> Result<()> {
                                             tx_request_track.send(true).await.unwrap();
                                         };
                                     }
-                                };
-                            };
 
-                            if let Err(err) = update_display(&local_state, &options).await {
-                                eprintln!("{}", err);
+                                    PlaybackStateDelta::Render => {
+                                        if let Err(err) = update_display(&local_state, &options).await {
+                                            eprintln!("{}", err);
+                                        };
+                                    }
+                                };
                             };
                         }
 

--- a/src/cmd/now.rs
+++ b/src/cmd/now.rs
@@ -218,6 +218,7 @@ pub async fn now(options: NowOptions) -> Result<()> {
                     tokio::select! {
                         _ = intvl.tick() => {
                             tx.send(PlaybackStateDelta::PositionTick).await.unwrap();
+                            tx.send(PlaybackStateDelta::Render).await.unwrap();
                         }
                         _ = shutdown_rx.changed() => break,
                     }
@@ -256,9 +257,12 @@ pub async fn now(options: NowOptions) -> Result<()> {
                                     PlaybackStateDelta::Position(position) => {
                                         local_state.position = position;
                                     }
+
                                     PlaybackStateDelta::PositionTick => {
-                                        if let Some(position) = local_state.position {
-                                            local_state.position = Some(position + 0.25);
+                                        if local_state.state == "playing" {
+                                            if let Some(position) = local_state.position {
+                                                local_state.position = Some(position + 0.25);
+                                            }
                                         }
                                     }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -76,14 +76,14 @@ pub fn format_duration_plain(duration_secs: &i32) -> String {
 
 pub fn format_player_state(raw: &str, nerd_fonts: bool) -> Result<String> {
     if nerd_fonts {
-        return match raw {
+        match raw {
             "stopped" => Ok("".into()),
             "playing" => Ok("".into()),
             "paused" => Ok("".into()),
             "fast forwarding" => Ok("".into()),
             "rewinding" => Ok("".into()),
             &_ => Err(anyhow!("Unexpected player state {}", raw)),
-        };
+        }
     } else {
         let mut ret = "".to_owned();
         for (idx, char) in raw.char_indices() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ async fn concise_now_playing() -> Result<()> {
         music::tell("get {artist} of current track"),
         music::tell("get {duration} of current track")
     )?;
-    let duration = duration.parse::<f32>()?;
+    let duration = duration.parse::<f64>()?;
 
     println!(
         "{} {}\n{} · {}",

--- a/src/music/metadata.rs
+++ b/src/music/metadata.rs
@@ -4,6 +4,8 @@ use url_escape::encode_component;
 
 use anyhow::{anyhow, Result};
 
+use super::Track;
+
 pub struct Metadata {
     pub id: String,
     pub album_artwork: String,
@@ -64,15 +66,11 @@ struct ArtistMetadataResult {
     artists: ArtistDataResult,
 }
 
-pub async fn get_metadata(
-    client: &Client,
-    artist: String,
-    album: String,
-    song: String,
-) -> Result<Metadata> {
-    let song_key_danger = artist.clone() + " " + &album + " " + &song;
+pub async fn get_metadata(client: &Client, track: &Track) -> Result<Metadata> {
+    let song_key_danger = track.artist.clone() + " " + &track.album + " " + &track.name;
     let song_key = encode_component(&song_key_danger);
-    let artist_key_danger = artist
+    let artist_key_danger = track
+        .artist
         .split(&[',', '&'][..])
         .next()
         .ok_or_else(|| anyhow!("Could not obtain artist to query with"))?;


### PR DESCRIPTION
Switches the `now` command to use multiple-producer single-consumer channels for data synchronization instead of mutexes.
