### PR TITLE
fix: normalize decimal separator when parsing track duration

### DIFF
--- a/src/cmd/discord/mod.rs
+++ b/src/cmd/discord/mod.rs
@@ -63,9 +63,7 @@ async fn update_presence(client: &mut DiscordIpcClient, state: &mut ActivityStat
         return Ok(());
     }
 
-    let position = position
-        .replace(",", ".")
-        .parse::<f64>()?;
+    let position = position.replace(",", ".").parse::<f64>()?;
 
     let track = music::get_current_track()
         .await?

--- a/src/cmd/discord/mod.rs
+++ b/src/cmd/discord/mod.rs
@@ -63,7 +63,7 @@ async fn update_presence(client: &mut DiscordIpcClient, state: &mut ActivityStat
         return Ok(());
     }
 
-    let position = position.replace(",", ".").parse::<f64>()?;
+    let position = position.replace(',', ".").parse::<f64>()?;
 
     let track = music::get_current_track()
         .await?

--- a/src/cmd/discord/mod.rs
+++ b/src/cmd/discord/mod.rs
@@ -63,7 +63,9 @@ async fn update_presence(client: &mut DiscordIpcClient, state: &mut ActivityStat
         return Ok(());
     }
 
-    let position = position.parse::<f64>()?;
+    let position = position
+        .replace(",", ".")
+        .parse::<f64>()?;
 
     let track = music::get_current_track()
         .await?

--- a/src/cmd/now.rs
+++ b/src/cmd/now.rs
@@ -98,7 +98,7 @@ async fn update_state(
             .map(|s| s.trim().to_owned());
 
         let player_position = player_position
-            .replace(",", ".")
+            .replace(',', ".")
             .parse::<f64>()
             .ok()
             .map(|p| p + time_latency);

--- a/src/cmd/now.rs
+++ b/src/cmd/now.rs
@@ -98,6 +98,7 @@ async fn update_state(
             .map(|s| s.trim().to_owned());
 
         let player_position = player_position
+            .replace(",", ".")
             .parse::<f64>()
             .ok()
             .map(|p| p + time_latency);

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ async fn concise_now_playing() -> Result<()> {
         .next()
         .ok_or_else(|| eyre!("Could not obtain track duration"))?
         .to_owned()
-        .replace(",", ".")
+        .replace(',', ".")
         .parse::<f64>()?;
 
     println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,7 @@ async fn concise_now_playing() -> Result<()> {
         .next()
         .ok_or_else(|| eyre!("Could not obtain track duration"))?
         .to_owned()
+        .replace(",", ".")
         .parse::<f64>()?;
 
     println!(

--- a/src/music/mod.rs
+++ b/src/music/mod.rs
@@ -161,6 +161,7 @@ pub async fn get_current_track() -> Result<Option<Track>> {
             .next()
             .ok_or_else(|| eyre!("Could not obtain track duration"))?
             .to_owned()
+            .replace(",", ".")
             .parse::<f64>()?;
 
         Ok(Some(Track {

--- a/src/music/mod.rs
+++ b/src/music/mod.rs
@@ -161,7 +161,7 @@ pub async fn get_current_track() -> Result<Option<Track>> {
             .next()
             .ok_or_else(|| eyre!("Could not obtain track duration"))?
             .to_owned()
-            .replace(",", ".")
+            .replace(',', ".")
             .parse::<f64>()?;
 
         Ok(Some(Track {


### PR DESCRIPTION
fixes #213 

The core of the issue: in my locale (Spanish), we separate the decimal part of a Float with a comma `,` instead of a period `.`. Of course, `.parse::<f...>` expects a period as the separator.
The fix is to do a replace every time we try to convert from the raw string. It's more or less safe, since I checked and it doesn't return the separator for the thousands (in my locale, a period), but is verbose.